### PR TITLE
Update Type for OME

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ app.get('/', (req, res) => {
  * once the minimum number of orders (as given by the BATCH_SIZE env variable) is met.
  */
 app.post('/submit', async (req, res) => {
-    let numOrders = orderStorage.getOrderCounter(req.body.maker.market)
+    let numOrders = orderStorage.getOrderCounter(req.body.maker.target_tracer)
     console.log(`Received Orders. Pending orders to process: ${numOrders}`)
 
     //Validate orders
@@ -38,19 +38,19 @@ app.post('/submit', async (req, res) => {
     }
 
     // //add the order to the order heap for this market
-    orderStorage.addOrders(req.body.maker, req.body.taker, req.body.maker.market)
+    orderStorage.addOrders(req.body.maker, req.body.taker, req.body.maker.target_tracer)
     //repoll the number of orders
-    numOrders = orderStorage.getOrderCounter(req.body.maker.market)
+    numOrders = orderStorage.getOrderCounter(req.body.maker.target_tracer)
 
     //If enough orders are present, process the orders on chain
     if (numOrders >= process.env.BATCH_SIZE) {
         //submit orders
         console.log(`Submitting ${numOrders} orders to contract`)
-        let ordersToSubmit = orderStorage.getAllOrders(req.body.maker.market)
-        await submitOrders(ordersToSubmit[0], ordersToSubmit[1], traderContract, req.body.maker.market, web3.eth.defaultAccount)
+        let ordersToSubmit = orderStorage.getAllOrders(req.body.maker.target_tracer)
+        await submitOrders(ordersToSubmit[0], ordersToSubmit[1], traderContract, req.body.maker.target_tracer, web3.eth.defaultAccount)
         //TODO: Decide on error handling for if submitOrders does not process for some reason.
         //clear order storage for this market
-        orderStorage.clearMarket(req.body.maker.market)
+        orderStorage.clearMarket(req.body.maker.target_tracer)
     }
 
     //Return

--- a/orderSerialisation.js
+++ b/orderSerialisation.js
@@ -33,9 +33,9 @@ const serialiseOrder = (rawOrder) => {
         amount: rawOrder.amount.toString(),
         price: rawOrder.price.toString(),
         side: rawOrder.side === "Bid",
-        user: web3.utils.toChecksumAddress(rawOrder.address),
+        user: web3.utils.toChecksumAddress(rawOrder.user),
         expiration: rawOrder.expiration,
-        targetTracer: web3.utils.toChecksumAddress(rawOrder.market),
+        targetTracer: web3.utils.toChecksumAddress(rawOrder.target_tracer),
         nonce: parseInt(rawOrder.nonce, 16)
     }
 

--- a/orderValidation.js
+++ b/orderValidation.js
@@ -4,8 +4,8 @@
 const validateOrder = (order) => {
   //Require all fields
   if (order.id === undefined ||
-    order.address === undefined ||
-    order.market === undefined ||
+    order.user === undefined ||
+    order.target_tracer === undefined ||
     order.side === undefined ||
     order.price === undefined ||
     order.amount === undefined ||
@@ -39,7 +39,7 @@ const validatePair = (make, take) => {
   }
 
   //Orders must be for same market
-  if (make.market !== take.market) {
+  if (make.target_tracer !== take.target_tracer) {
     console.log("Order validation: Invalid market in pair")
     return false
   }


### PR DESCRIPTION
# Motivation
This PR (tracer-protocol/tracer-ome#7) for the Tracer OME changes field names for the order type in the OME (to keep it consistent with the contracts). The executioner needs to know about these changes in order to successfully deserialise orders from the OME and submit them on chain.

# Changes
- replace use of market with target_tracer
- replace use of address with user