### PR TITLE
gas configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ app.post('/submit', async (req, res) => {
         console.log(`Submitting ${numOrders} orders to contract`)
         let ordersToSubmit = orderStorage.getAllOrders(req.body.maker.target_tracer)
         try {
-            await submitOrders(ordersToSubmit[0], ordersToSubmit[1], traderContract, web3.eth.defaultAccount)
+            await submitOrders(ordersToSubmit[0], ordersToSubmit[1], traderContract, process.env.GAS_LIMIT)
             //TODO: Decide on error handling for if submitOrders does not process for some reason.
             //clear order storage for this market
             orderStorage.clearMarket(req.body.maker.target_tracer)

--- a/orderSubmission.js
+++ b/orderSubmission.js
@@ -5,13 +5,11 @@ const web3 = require("web3")
 /**
  * Submit orders to the on chain trader contract.
  */
-const submitOrders = async (makerOrders, takerOrders, contract, sendingAccount) => {
+const submitOrders = async (makerOrders, takerOrders, contract, gasLimit) => {
     let serialisedMakeOrders = makerOrders.map((order) => omeOrderToOrder(web3, order))
     let serialisedTakeOrders = takerOrders.map((order) => omeOrderToOrder(web3, order))
     try {
-        let gas = await contract.methods.executeTrade(serialisedMakeOrders, serialisedTakeOrders).estimateGas({ from: sendingAccount })
-        let txn = await contract.methods.executeTrade(serialisedMakeOrders, serialisedTakeOrders).send({ from: sendingAccount, gas: 1500000 })
-        return txn
+        return await contract.executeTrade(serialisedMakeOrders, serialisedTakeOrders, { gasLimit: gasLimit })
     } catch (e) {
         console.error(e)
         throw e


### PR DESCRIPTION
# Motivation
The tracer-utils package did not yet support Ethers, however changes from the PR that added ethers were still wanted, namely allowing gas to be configurable.

# Changes
- use env var for gas limit
- pass to contract call