### PR TITLE
Change check endpoint response codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,11 @@ app.post('/check', async (req, res) => {
     let signature = web3.utils.bytesToHex(omeOrder.signed_data)
 
     let isValidSig = validateSignature(contractOrder.order, process.env.TRADER_CONTRACT, network, signature)
-    console.log(isValidSig)
-    return res.status(200).send({ verified: isValidSig })
+    if (isValidSig) {
+        return res.status(200)
+    } else {
+        return res.status(400)
+    }
 })
 
 /**


### PR DESCRIPTION
# Motivation
For simplicity, the OME checks if the status code of this endpoint is `ok` or not. Since no other service requires this endpoint, returning a bool represented in status codes is fine.

# Changes
- return 400 when signature is not valid.