### PR TITLE
Fix check endpoint response

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,9 @@ app.post('/check', async (req, res) => {
 
     let isValidSig = validateSignature(contractOrder.order, process.env.TRADER_CONTRACT, network, signature)
     if (isValidSig) {
-        return res.status(200)
+        return res.status(200).send()
     } else {
-        return res.status(400)
+        return res.status(400).send()
     }
 })
 

--- a/index.js
+++ b/index.js
@@ -83,8 +83,11 @@ app.post('/check', async (req, res) => {
     let signature = web3.utils.bytesToHex(omeOrder.signed_data)
 
     let isValidSig = validateSignature(contractOrder.order, process.env.TRADER_CONTRACT, network, signature)
-    console.log(isValidSig)
-    return res.status(200).send({ verified: isValidSig })
+    if (isValidSig) {
+        return res.status(200)
+    } else {
+        return res.status(400)
+    }
 })
 
 /**


### PR DESCRIPTION
# Motivation
The `/check` endpoint was not actually returning a response. This caused the OME to hang.

# Changes
- add `send()` to the endpoint to flush the response