### PR TITLE
[order validation] use trueMaxLeverage instead of maxLeverage 

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ app.post('/check', async (req, res) => {
     const perpetualSwapContract = new web3.eth.Contract(perpetualSwapABI, contractOrder.order.market)
 
     const feeRate = await perpetualSwapContract.methods.feeRate().call()
-    const maxLeverage = await perpetualSwapContract.methods.maxLeverage().call()
+    const trueMaxLeverage = await perpetualSwapContract.methods.trueMaxLeverage().call()
 
     const currentPosition = await perpetualSwapContract.methods.getBalance(contractOrder.order.maker).call()
 
@@ -141,7 +141,7 @@ app.post('/check', async (req, res) => {
             side: contractOrder.order.side
         },
         feeRate: accounting.fromWad(feeRate),
-        maxLeverage: accounting.fromWad(maxLeverage)
+        maxLeverage: accounting.fromWad(trueMaxLeverage)
     })
 
     if(!isValidMarginAfterTrade) {


### PR DESCRIPTION
# Motivation
I was reading [through documentation](https://mycelium-eth.atlassian.net/wiki/spaces/LM/pages/357302666/Tracer+Perpetual+Swaps+System+Architecture) and realized I should be using  trueMaxLeverage here instead (at least I'm pretty sure)

# Changes
instead of using `maxLeverage` from the deployed Tracer during order validation, I am now using `trueMaxLeverage`